### PR TITLE
move dev dependencies to an appropriate section

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
   "author": "piotr.fryga@allegrogroup.com",
   "license": "MIT",
   "dependencies": {
-    "append-query": "^1.1.0",
+    "append-query": "^1.1.0"
+  },
+  "devDependencies": {
+    "babel-register": "^6.7.2",
     "mocha": "^2.4.5",
     "mocha-junit-reporter": "^1.0.0",
     "mocha-multi": "^0.7.0",
     "should": "^7.0.0"
-  },
-  "devDependencies": {
-    "babel-register": "^6.7.2"
   }
 }


### PR DESCRIPTION
- A bunch of packages that was exclusively used in tests, was incorrectly listed as runtime dependencies. Thus they were installed unnecessarily every time this package was used as a direct or indirect dependency.
- This change moves it to appropriate section.